### PR TITLE
Minor fix for when there are completers with no applicable commands

### DIFF
--- a/TabExpansion++.psm1
+++ b/TabExpansion++.psm1
@@ -660,6 +660,16 @@ function Flush-BackgroundResultsQueue
     while ($backgroundResultsQueue.TryDequeue([ref]$item))
     {
         $parameters = $item.Value
+        if( !($parameters[ 'CommandName' ]) )
+        {
+            # This can happen, for example, if you have a completer where the
+            # applicable 'Command' is determined by running a script block, and
+            # the script block returns no results. (For instance, "Command = {
+            # Get-CommandWithParameter -Module Hyper-V ... }", and you don't
+            # have the Hyper-V module installed.)
+            continue
+        }
+
         if ($item.ArgumentCompleter)
         {
             Register-ArgumentCompleter @parameters 


### PR DESCRIPTION
This is the thing that is always populating my $Error with stuff, because I don't have the Hyper-V module installed.
