### PR TITLE
New completers and code enhancements

### DIFF
--- a/CimCmdlets.ps1
+++ b/CimCmdlets.ps1
@@ -1,0 +1,86 @@
+## CimCmdlets module Custom Completers ##
+
+#
+# .SYNOPSIS
+#
+#    Complete the -QueryDialect argument to CimCmdlets cmdlets
+#
+function CimInstance_QueryDialectCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'QueryDialect',
+        Command = {Get-CommandWithParameter -Module CimCmdlets -ParameterName QueryDialect},
+        Description = 'Complete the -QueryDialect argument to CimInstance cmdlets:  Get-CimInstance -QueryDialect  -QueryDialect <TAB>'
+    )]
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+    Write-Output CQL WQL | Where-Object {$_ -like "$wordToComplete*"} | ForEach-Object {
+        New-CompletionResult $_ $_
+    }
+}
+
+
+
+#
+# .SYNOPSIS
+#
+#    Complete the -Property argument to Get-CimInstance
+#
+function CimInstance_PropertyParameterCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'Property',
+        Command = 'Get-CimInstance',
+        Description = 'Complete the -Property argument to CimInstance cmdlets: Get-CimInstance -Class Win32_Process -Property <TAB>'
+    )]
+   param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+   $param = @{}
+   $ns = $fakeBoundParameter['Namespace']
+   $cn = $fakeBoundParameter['ComputerName']
+   $cs = $fakeBoundParameter['CimSession']
+   $cl = $fakeBoundParameter['ClassName']
+   
+   if($ns) {$param.Namespace = $ns}
+   if($cn) {$param.ComputerName = $cn}
+   if($cs) {$param.CimSession = $cs}   
+   if($cl) {$param.ClassName = $cl} 
+
+   (CimCmdlets\Get-CimClass @param).CimClassProperties.Name | Where-Object {$_ -like "$wordToComplete*"} | Sort-Object | Foreach-Object { 
+    New-CompletionResult $_ $_
+   }
+}
+
+
+
+#
+# .SYNOPSIS
+#
+#    Complete the -ResultClassName argument to Get-CimAssociatedInstance
+#
+
+function CimInstance_CimAssociatedInstanceResultClassNameParameterCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'ResultClassName',
+        Command = 'Get-CimAssociatedInstance',
+        Description = 'Complete the -ResultClassName argument to Get-CimAssociatedInstance: $disk = Get-CimInstance -Class Win32_LogicalDisk -Filter 'DriveType=3'; Get-CimAssociatedInstance -CimInstance $disk -ResultClassName <TAB>'
+    )]
+   param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+   $param = @{}
+   $ns = $fakeBoundParameter['Namespace']
+   $cn = $fakeBoundParameter['ComputerName']
+   $ci = $fakeBoundParameter['CimInstance']
+   $io = $fakeBoundParameter['InputObject']
+   
+   if($ns) {$param.Namespace = $ns}
+   if($cn) {$param.ComputerName = $cn}
+   if($ci) {$param.CimInstance = $ci}   
+   if($io) {$param.InputObject = $io} 
+   
+   (CimCmdlets\Get-CimAssociatedInstance @param).CimClass.CimClassName | Where-Object {$_ -like "$wordToComplete*"} | Sort-Object | Foreach-Object { 
+    New-CompletionResult $_ $_
+   }
+}
+

--- a/ISE.ps1
+++ b/ISE.ps1
@@ -1,0 +1,20 @@
+﻿## ISE custom Completers ##
+
+#
+# .SYNOPSIS
+#
+#    Complete the -Module argument to Import-IseSnippet
+#
+function IseSnippetModuleCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'Module',
+        Command = 'Import-IseSnippet',
+        Description = 'Complete the -Module argument to Import-IseSnippet: Import-IseSnippet -Module <TAB>'
+    )]
+   param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+   Microsoft.PowerShell.Core\Get-Module -Name "$wordToComplete*" -ListAvailable | Sort-Object Name | Foreach-Object { 
+	New-CompletionResult $_.Name $_.Name
+   }
+}

--- a/Microsoft.PowerShell.Core.ArgumentCompleters.ps1
+++ b/Microsoft.PowerShell.Core.ArgumentCompleters.ps1
@@ -231,3 +231,22 @@ function ScopeParameterCompleter
     }
 }
 
+
+# .SYNOPSIS
+#
+#    Complete the -Name argument to Import-Module
+#
+function ImportModuleNameCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'Name',
+        Command = 'Import-Module',
+        Description = 'Complete the -Name argument to Import-Module, for example:  Import-Module -Name <TAB>'
+    )]
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+    Microsoft.PowerShell.Core\Get-Module -ListAvailable -Name "$wordToComplete*" | Sort-Object Name | ForEach-Object {
+        $tooltip = "Description: {0}`nModuleType: {1}`nPath: {2}" -f $_.Description,$_.ModuleType,$_.Path
+        New-CompletionResult $_.Name $tooltip
+    }
+}

--- a/Microsoft.PowerShell.Diagnostics.ArgumentCompleters.ps1
+++ b/Microsoft.PowerShell.Diagnostics.ArgumentCompleters.ps1
@@ -1,4 +1,4 @@
-﻿
+
 #
 # .SYNOPSIS
 #
@@ -94,4 +94,44 @@ function GetWinEvent_LogNameCompleter
             $toolTip = "Log $($_.LogName): $($_.RecordCount) entries"
             New-CompletionResult $_.LogName $toolTip
         }
+}
+
+
+#
+# .SYNOPSIS
+#
+#     Completes names of the logs for Get-WinEvent cmdlet.
+#
+function GetWinEvent_ListLogCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'ListLog',
+        Command = 'Get-WinEvent',
+        Description = 'Completes names for the logs, for example:  Get-WinEvent -ListLog <TAB>'
+    )]
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+    [System.Diagnostics.Eventing.Reader.EventLogSession]::GlobalSession.GetLogNames() | Where-Object {$_ -like "*$wordToComplete*"} | Sort-Object | ForEach-Object {
+            New-CompletionResult $_ $_
+    }
+}
+
+
+#
+# .SYNOPSIS
+#
+#     Completes providers names for Get-WinEvent cmdlet.
+#
+function GetWinEvent_ListProviderCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'ListProvider',
+        Command = 'Get-WinEvent',
+        Description = 'Completes names of the providers, for example:  Get-WinEvent -ListProvider <TAB>'
+    )]
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+    [System.Diagnostics.Eventing.Reader.EventLogSession]::GlobalSession.GetProviderNames() | Where-Object {$_ -like "*$wordToComplete*"} | Sort-Object | ForEach-Object {
+            New-CompletionResult $_ $_
+    }
 }

--- a/Microsoft.PowerShell.Management.ArgumentCompleters.ps1
+++ b/Microsoft.PowerShell.Management.ArgumentCompleters.ps1
@@ -1,4 +1,36 @@
-﻿
+#
+# .SYNOPSIS
+#
+#    Complete the -Namespace argument to Wmi cmdlets (similiar to buil-in cim cmdlets namespace completion support)
+#
+function WmiNamespaceCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'Namespace',
+        Command = {Get-CommandWithParameter -Noun wmi* -ParameterName Namespace},
+        Description = 'Complete the -Namespace argument to Wmi cmdlets. For example: Get-WmiObject -Namespace <TAB>'
+    )]
+   param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+    $nsParent='root'
+
+    if ($wordToComplete)
+    {
+        [int]$delimiter = $wordToComplete.LastIndexOfAny([char[]]('\','/'))
+        if($delimiter -ne -1)
+        {
+                $nsParent = $wordToComplete.Substring(0,$delimiter)
+                $nsLeaf = $wordToComplete.Substring($delimiter+1)
+        }
+    }
+
+   Microsoft.PowerShell.Management\Get-WmiObject -Class __NAMESPACE -Namespace $nsParent | Where-Object Name -like $nsLeaf* | Sort-Object Name | ForEach-Object { 
+         $namespace = '{0}/{1}' -f $nsParent.Replace('\','/'),$_.Name
+         New-CompletionResult $namespace $namespace
+   }
+}
+
+
 #
 # .SYNOPSIS
 #

--- a/Microsoft.PowerShell.Utility.ArgumentCompleters.ps1
+++ b/Microsoft.PowerShell.Utility.ArgumentCompleters.ps1
@@ -1,4 +1,4 @@
-﻿
+
 #
 # Reading the registry for progids takes > 500ms, so we do it at module load time.
 #
@@ -169,4 +169,44 @@ function Ps1xmlPathArgumentCompletion
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
 
     Get-CompletionWithExtension $lastWord '.ps1xml'
+}
+
+
+#
+# .SYNOPSIS
+#
+#    Complete the -SerializationMethod argument to Update-TypeData
+#
+function UpdateTypeDataSerializationMethodCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'SerializationMethod',
+        Command = 'Update-TypeData',
+        Description = 'Complete the -SerializationMethod argument to Update-TypeData. For example: Update-TypeData -SerializationMethod <TAB>')]
+   param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+   $sm = [PSObject].Assembly.GetType('System.Management.Automation.SerializationMethod')
+   [System.Enum]::GetNames($sm) | Where-Object {$_ -like "*$wordToComplete*"} | Sort-Object | Foreach-Object {
+    New-CompletionResult $_ $_
+   }
+}
+
+
+#
+# .SYNOPSIS
+#
+#     Complete the SourceIdentifier argument to Register-EngineEvent
+#
+function EventNameCompletion
+{
+    [ArgumentCompleter(
+        Parameter = 'SourceIdentifier',
+        Command = 'Register-EngineEvent',
+        Description = 'Complete the -SourceIdentifier argument for Register-ObjectEvent, for example: Register-EngineEvent -SourceIdentifier <TAB>'
+    )]
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+    [System.Management.Automation.PsEngineEvent].GetFields() | ForEach-Object { $_.GetValue($null) } | Sort-Object | Where-Object {$_ -like "*$wordToComplete*"} | ForEach-Object { 
+        New-CompletionResult  $_ $_
+    }
 }

--- a/TabExpansionPlusPlus.ps1
+++ b/TabExpansionPlusPlus.ps1
@@ -1,0 +1,20 @@
+## TabExpansion++ custom Completers ##
+
+#
+# .SYNOPSIS
+#
+#    Complete the -FilePath argument to Update-ArgumentCompleter
+#
+function UpdateArgumentFilePathCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'FilePath',
+        Command = 'Update-ArgumentCompleter',
+        Description = 'Complete the -FilePath argument to Update-ArgumentCompleter: Update-ArgumentCompleter -FilePath <TAB>'
+    )]
+   param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+   TabExpansion++\Get-ArgumentCompleter | Where-Object File -like *$wordToComplete* | ForEach-Object File | Sort-Object -Unique | Foreach-Object { 
+    New-CompletionResult "$PSScriptRoot\$_" $_
+   }
+}


### PR DESCRIPTION
Code enhancements
1.  Added verbose messages to Update-ArgumentCompleter. Sample output:

VERBOSE: Scanning for completer files...
VERBOSE: Registering completer 'Clean-MailboxDatabase
Get-MailboxDatabase Remove-MailboxDatabase'
VERBOSE: found initialization function, creating key: 'ex2010'
(...)
1. Added FilePath parameter to Update-ArgumentCompleter. Developing
   completers can be a daunting task especially when you introduce rapid
   changes to a completer file. Having to to load ALL completers in order
   to load your changes can take very long time to complete and  slows down
   development time. FilePath allows loading a specific file(s). On a side
   note, a new completer file was added too to support file path completion
   from the module base path.

New module completers
1. CimCmdlets
2. ISE

New custom completers
1. Import-Module Name Completer (core)
2. Get-WinEvent, ListLog and ListProvider completers (diagnostics)
3. WMI Namespace completer (similiar to buil-in cim cmdlets namespace
   completion support)
4. Update-TypeData SerializationMethod completer (utility)
5. Register-EngineEvent SourceIdentifier completer (utility)
6. Update-ArgumentFilePathCompleter (TabExpansionPlusPlus.ps1)
