### PR TITLE
Adding Azure PowerShell auto-completers / added results completion caching mechanism

### DIFF
--- a/Microsoft.Azure.ArgumentCompleters.ps1
+++ b/Microsoft.Azure.ArgumentCompleters.ps1
@@ -17,28 +17,28 @@ function StorageAccount_StorageAccountNameCompleter
     )]
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
 
-    #Write-Verbose -Message ('Called Azure StorageAccountName completer at {0}' -f (Get-Date));
+    #Write-Verbose -Message ('Called Azure StorageAccountName completer at {0}' -f (Get-Date))
 
-    $CacheKey = 'StorageAccount_StorageAccountNameCache';
-    $StorageAccountNameCache = Get-CompletionPrivateData -Key $CacheKey;
+    $CacheKey = 'StorageAccount_StorageAccountNameCache'
+    $StorageAccountNameCache = Get-CompletionPrivateData -Key $CacheKey
 
     ### Return the cached value if it has not expired
     if ($StorageAccountNameCache) {
-        return $StorageAccountNameCache;
+        return $StorageAccountNameCache
     }
 
-    $StorageAccountList = Get-AzureStorageAccount -WarningAction SilentlyContinue | Where-Object {$PSItem.StorageAccountName -match ${wordToComplete}; } | ForEach-Object {
+    $StorageAccountList = Get-AzureStorageAccount -WarningAction SilentlyContinue | Where-Object {$PSItem.StorageAccountName -match ${wordToComplete} } | ForEach-Object {
         $CompletionResult = @{
-            CompletionText = $PSItem.StorageAccountName;
-            ToolTip = 'Storage Account "{0}" in "{1}" region.' -f $PSItem.StorageAccountName, $PSItem.Location;
-            ListItemText = '{0} ({1})' -f $PSItem.StorageAccountName, $PSItem.Location;
-            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue;
-            };
-        New-CompletionResult @CompletionResult;
+            CompletionText = $PSItem.StorageAccountName
+            ToolTip = 'Storage Account "{0}" in "{1}" region.' -f $PSItem.StorageAccountName, $PSItem.Location
+            ListItemText = '{0} ({1})' -f $PSItem.StorageAccountName, $PSItem.Location
+            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue
+            }
+        New-CompletionResult @CompletionResult
     }
 
-    Set-CompletionPrivateData -Key $CacheKey -Value $StorageAccountList;
-    return $StorageAccountList;
+    Set-CompletionPrivateData -Key $CacheKey -Value $StorageAccountList
+    return $StorageAccountList
 }
 
 #
@@ -55,31 +55,31 @@ function AzureStorage_StorageContainerNameCompleter
 {
     [ArgumentCompleter(
         Parameter = 'Name',
-        Command = { Get-CommandWithParameter -Module Azure -ParameterName Name -Name *container*; },
+        Command = { Get-CommandWithParameter -Module Azure -ParameterName Name -Name *container* },
         Description = 'Complete the -Name parameter value for Azure cmdlets:  Get-AzureStorageContainer -Context $Context -Name <TAB>'
     )]
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
 
-    $CacheKey = 'AzureStorage_ContainerNameCache';
-    $ContainerNameCache = Get-CompletionPrivateData -Key $CacheKey;
+    $CacheKey = 'AzureStorage_ContainerNameCache'
+    $ContainerNameCache = Get-CompletionPrivateData -Key $CacheKey
 
     ### Return the cached value if it has not expired
     if ($ContainerNameCache) {
-        return $ContainerNameCache;
+        return $ContainerNameCache
     }
 
-    $ContainerList = Get-AzureStorageContainer -Context $fakeBoundParameter['Context'] | Where-Object -FilterScript { $PSItem.Name -match ${wordToComplete}; } | ForEach-Object {
+    $ContainerList = Get-AzureStorageContainer -Context $fakeBoundParameter['Context'] | Where-Object -FilterScript { $PSItem.Name -match ${wordToComplete} } | ForEach-Object {
         $CompletionResult = @{
-            CompletionText = $PSItem.Name;
-            ToolTip = 'Storage Container "{0}" in "{1}" Storage Account.' -f $PSItem.Name, $fakeBoundParameter['Context'].StorageAccountName;
-            ListItemText = '{0} ({1})' -f $PSItem.Name, $fakeBoundParameter['Context'].StorageAccountName;
-            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue;
-            };
-        New-CompletionResult @CompletionResult;
+            CompletionText = $PSItem.Name
+            ToolTip = 'Storage Container "{0}" in "{1}" Storage Account.' -f $PSItem.Name, $fakeBoundParameter['Context'].StorageAccountName
+            ListItemText = '{0} ({1})' -f $PSItem.Name, $fakeBoundParameter['Context'].StorageAccountName
+            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue
+            }
+        New-CompletionResult @CompletionResult
     }
 
-    Set-CompletionPrivateData -Key $CacheKey -Value $ContainerList;
-    return $ContainerList;
+    Set-CompletionPrivateData -Key $CacheKey -Value $ContainerList
+    return $ContainerList
 }
 
 #
@@ -101,25 +101,25 @@ function CloudService_ServiceNameCompleter
     )]
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
 
-    #Write-Verbose -Message ('Called Azure ServiceName completer at {0}' -f (Get-Date));
-    $CacheKey = 'CloudService_ServiceNameCache';
-    $ServiceNameCache = Get-CompletionPrivateData -Key $CacheKey;
+    #Write-Verbose -Message ('Called Azure ServiceName completer at {0}' -f (Get-Date))
+    $CacheKey = 'CloudService_ServiceNameCache'
+    $ServiceNameCache = Get-CompletionPrivateData -Key $CacheKey
     if ($ServiceNameCache) {
-        return $ServiceNameCache;
+        return $ServiceNameCache
     }
 
-    $ItemList = Get-AzureService | Where-Object { $PSItem.ServiceName -match ${wordToComplete}; } | ForEach-Object {
+    $ItemList = Get-AzureService | Where-Object { $PSItem.ServiceName -match ${wordToComplete} } | ForEach-Object {
         $CompletionResult = @{
-            CompletionText = $PSItem.ServiceName;
-            ToolTip = 'Cloud Service in "{0}" region.' -f $PSItem.ExtendedProperties.ResourceLocation;
-            ListItemText = '{0} ({1})' -f $PSItem.ServiceName, $PSItem.ExtendedProperties.ResourceLocation;
-            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue;
-            };
-        New-CompletionResult @CompletionResult;
+            CompletionText = $PSItem.ServiceName
+            ToolTip = 'Cloud Service in "{0}" region.' -f $PSItem.ExtendedProperties.ResourceLocation
+            ListItemText = '{0} ({1})' -f $PSItem.ServiceName, $PSItem.ExtendedProperties.ResourceLocation
+            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue
+            }
+        New-CompletionResult @CompletionResult
     }
-    Set-CompletionPrivateData -Key $CacheKey -Value $ItemList;
+    Set-CompletionPrivateData -Key $CacheKey -Value $ItemList
 
-    return $ItemList;
+    return $ItemList
 }
 
 #
@@ -141,33 +141,33 @@ function Subscription_SubscriptionNameCompleter
     )]
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
 
-    #Write-Verbose -Message ('Called Azure SubscriptionName completer at {0}' -f (Get-Date));
+    #Write-Verbose -Message ('Called Azure SubscriptionName completer at {0}' -f (Get-Date))
 
     ### Attempt to read Azure subscription details from the cache
-    $CacheKey = 'AzureSubscription_SubscriptionNameCache';
-    $SubscriptionNameCache = Get-CompletionPrivateData -Key $CacheKey;
+    $CacheKey = 'AzureSubscription_SubscriptionNameCache'
+    $SubscriptionNameCache = Get-CompletionPrivateData -Key $CacheKey
 
     ### If there is a valid cache for the Azure subscription names, then go ahead and return them immediately
     if ($SubscriptionNameCache) {
-        return $SubscriptionNameCache;
+        return $SubscriptionNameCache
     }
 
     ### Create fresh completion results for Azure subscriptions
-    $ItemList = Get-AzureSubscription | Where-Object { $PSItem.SubscriptionName -match ${wordToComplete}; } | ForEach-Object {
+    $ItemList = Get-AzureSubscription | Where-Object { $PSItem.SubscriptionName -match ${wordToComplete} } | ForEach-Object {
         $CompletionResult = @{
-            CompletionText = $PSItem.SubscriptionName;
-            ToolTip = 'Azure subscription "{0}" with ID {1}.' -f $PSItem.SubscriptionName, $PSItem.SubscriptionId;
-            ListItemText = '{0} ({1})' -f $PSItem.SubscriptionName, $PSItem.SubscriptionId;
-            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue;
-            };
-        New-CompletionResult @CompletionResult;
+            CompletionText = $PSItem.SubscriptionName
+            ToolTip = 'Azure subscription "{0}" with ID {1}.' -f $PSItem.SubscriptionName, $PSItem.SubscriptionId
+            ListItemText = '{0} ({1})' -f $PSItem.SubscriptionName, $PSItem.SubscriptionId
+            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue
+            }
+        New-CompletionResult @CompletionResult
     }
     
     ### Update the cache for Azure subscription names
-    Set-CompletionPrivateData -Key $CacheKey -Value $ItemList;
+    Set-CompletionPrivateData -Key $CacheKey -Value $ItemList
 
     ### Return the fresh completion results
-    return $ItemList;
+    return $ItemList
 }
 
 #
@@ -185,36 +185,36 @@ function AzureVirtualMachine_NameCompleter
 {
     [ArgumentCompleter(
         Parameter = 'Name',
-        Command = { Get-CommandWithParameter -Module Azure -ParameterName Name -Noun AzureVM; },
+        Command = { Get-CommandWithParameter -Module Azure -ParameterName Name -Noun AzureVM },
         Description = 'Complete the -Name parameter value for Azure virtual machine cmdlets:  Stop-AzureVM -Name <TAB>'
     )]
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
 
-    #Write-Verbose -Message ('Called Azure Virtual Machine Name completer at {0}' -f (Get-Date));
+    #Write-Verbose -Message ('Called Azure Virtual Machine Name completer at {0}' -f (Get-Date))
 
     ### Attempt to read Azure virtual machine details from the cache
-    $CacheKey = 'AzureVirtualMachine_NameCache';
-    $VirtualMachineNameCache = Get-CompletionPrivateData -Key $CacheKey;
+    $CacheKey = 'AzureVirtualMachine_NameCache'
+    $VirtualMachineNameCache = Get-CompletionPrivateData -Key $CacheKey
 
     ### If there is a valid cache for the Azure virtual machine names, then go ahead and return them immediately
     if ($VirtualMachineNameCache -and (Get-Date) -gt $VirtualMachineNameCache.ExpirationTime) {
-        return $VirtualMachineNameCache;
+        return $VirtualMachineNameCache
     }
 
     ### Create fresh completion results for Azure virtual machines
-    $ItemList = Get-AzureVM | Where-Object { $PSItem.Name -match ${wordToComplete}; } | ForEach-Object {
+    $ItemList = Get-AzureVM | Where-Object { $PSItem.Name -match ${wordToComplete} } | ForEach-Object {
         $CompletionResult = @{
-            CompletionText = '{0} -ServiceName {1}' -f $PSItem.Name, $PSItem.ServiceName;
-            ToolTip = 'Azure VM {0}/{1} in state {2}.' -f $PSItem.ServiceName, $PSItem.Name, $PSItem.Status;
-            ListItemText = '{0}/{1}' -f $PSItem.ServiceName, $PSItem.Name;
-            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue;
-            };
-        New-CompletionResult @CompletionResult;
+            CompletionText = '{0} -ServiceName {1}' -f $PSItem.Name, $PSItem.ServiceName
+            ToolTip = 'Azure VM {0}/{1} in state {2}.' -f $PSItem.ServiceName, $PSItem.Name, $PSItem.Status
+            ListItemText = '{0}/{1}' -f $PSItem.ServiceName, $PSItem.Name
+            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue
+            }
+        New-CompletionResult @CompletionResult
     }
     
     ### Update the cache for Azure virtual machines
-    Set-CompletionPrivateData -Key $CacheKey -Value $ItemList;
+    Set-CompletionPrivateData -Key $CacheKey -Value $ItemList
 
     ### Return the fresh completion results
-    return $ItemList;
+    return $ItemList
 }

--- a/Microsoft.Azure.ArgumentCompleters.ps1
+++ b/Microsoft.Azure.ArgumentCompleters.ps1
@@ -1,0 +1,177 @@
+﻿#
+# .SYNOPSIS
+#
+#    Auto-complete the -StorageAccountName parameter value for Azure PowerShell cmdlets.
+#
+# .NOTES
+#    
+#    Created by Trevor Sullivan <pcgeek86@gmail.com>
+#    http://trevorsullivan.net
+#
+function StorageAccount_StorageAccountNameCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'StorageAccountName',
+        Command = { Get-CommandWithParameter -Module Azure -ParameterName StorageAccountName },
+        Description = 'Complete the -StorageAccountName parameter value for Azure cmdlets:  Get-AzureStorageAccount -StorageAccountName <TAB>'
+    )]
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+    #Write-Verbose -Message ('Called Azure StorageAccountName completer at {0}' -f (Get-Date));
+
+    $CacheKey = 'StorageAccount_StorageAccountNameCache';
+    $StorageAccountNameCache = Get-CompletionPrivateData -Key $CacheKey;
+    if ($StorageAccountNameCache) {
+        return $StorageAccountNameCache;
+    }
+
+    $StorageAccountList = Get-AzureStorageAccount -WarningAction SilentlyContinue | Where-Object {$PSItem.StorageAccountName -match ${wordToComplete}; } | ForEach-Object {
+        $CompletionResult = @{
+            CompletionText = $PSItem.StorageAccountName;
+            ToolTip = 'Storage Account "{0}" in "{1}" region.' -f $PSItem.StorageAccountName, $PSItem.Location;
+            ListItemText = '{0} ({1})' -f $PSItem.StorageAccountName, $PSItem.Location;
+            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue;
+            };
+        New-CompletionResult @CompletionResult;
+    }
+
+    Set-CompletionPrivateData -Key $CacheKey -Value $StorageAccountList;
+    return $StorageAccountList;
+}
+
+#
+# .SYNOPSIS
+#
+#    Auto-complete the -ServiceName parameter value for Azure PowerShell cmdlets.
+#
+# .NOTES
+#    
+#    Created by Trevor Sullivan <pcgeek86@gmail.com>
+#    http://trevorsullivan.net
+#
+function CloudService_ServiceNameCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'ServiceName',
+        Command = { Get-CommandWithParameter -Module Azure -ParameterName ServiceName },
+        Description = 'Complete the -ServiceName parameter value for Azure cmdlets:  Get-AzureService -ServiceName <TAB>'
+    )]
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+    #Write-Verbose -Message ('Called Azure ServiceName completer at {0}' -f (Get-Date));
+    $CacheKey = 'CloudService_ServiceNameCache';
+    $ServiceNameCache = Get-CompletionPrivateData -Key $CacheKey;
+    if ($ServiceNameCache) {
+        return $ServiceNameCache;
+    }
+
+    $ItemList = Get-AzureService | Where-Object { $PSItem.ServiceName -match ${wordToComplete}; } | ForEach-Object {
+        $CompletionResult = @{
+            CompletionText = $PSItem.ServiceName;
+            ToolTip = 'Cloud Service in "{0}" region.' -f $PSItem.ExtendedProperties.ResourceLocation;
+            ListItemText = '{0} ({1})' -f $PSItem.ServiceName, $PSItem.ExtendedProperties.ResourceLocation;
+            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue;
+            };
+        New-CompletionResult @CompletionResult;
+    }
+    Set-CompletionPrivateData -Key $CacheKey -Value $ItemList;
+
+    return $ItemList;
+}
+
+#
+# .SYNOPSIS
+#
+#    Auto-complete the -SubscriptionName parameter value for Azure PowerShell cmdlets.
+#
+# .NOTES
+#    
+#    Created by Trevor Sullivan <pcgeek86@gmail.com>
+#    http://trevorsullivan.net
+#
+function Subscription_SubscriptionNameCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'SubscriptionName',
+        Command = { Get-CommandWithParameter -Module Azure -ParameterName SubscriptionName },
+        Description = 'Complete the -SubscriptionName parameter value for Azure cmdlets:  Select-AzureSubscription -SubscriptionName <TAB>'
+    )]
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+    #Write-Verbose -Message ('Called Azure SubscriptionName completer at {0}' -f (Get-Date));
+
+    ### Attempt to read Azure subscription details from the cache
+    $CacheKey = 'AzureSubscription_SubscriptionNameCache';
+    $SubscriptionNameCache = Get-CompletionPrivateData -Key $CacheKey;
+
+    ### If there is a valid cache for the Azure subscription names, then go ahead and return them immediately
+    if ($SubscriptionNameCache) {
+        return $SubscriptionNameCache;
+    }
+
+    ### Create fresh completion results for Azure subscriptions
+    $ItemList = Get-AzureSubscription | Where-Object { $PSItem.SubscriptionName -match ${wordToComplete}; } | ForEach-Object {
+        $CompletionResult = @{
+            CompletionText = $PSItem.SubscriptionName;
+            ToolTip = 'Azure subscription "{0}" with ID {1}.' -f $PSItem.SubscriptionName, $PSItem.SubscriptionId;
+            ListItemText = '{0} ({1})' -f $PSItem.SubscriptionName, $PSItem.SubscriptionId;
+            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue;
+            };
+        New-CompletionResult @CompletionResult;
+    }
+    
+    ### Update the cache for Azure subscription names
+    Set-CompletionPrivateData -Key $CacheKey -Value $ItemList;
+
+    ### Return the fresh completion results
+    return $ItemList;
+}
+
+#
+# .SYNOPSIS
+#
+#    Auto-complete the -Name parameter value for Azure PowerShell virtual machine cmdlets.
+#
+# .NOTES
+#    
+#    Created by Trevor Sullivan <pcgeek86@gmail.com>
+#    http://trevorsullivan.net
+#    http://twitter.com/pcgeek86
+#
+function AzureVirtualMachine_NameCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'Name',
+        Command = { Get-CommandWithParameter -Module Azure -ParameterName Name -Noun AzureVM; },
+        Description = 'Complete the -Name parameter value for Azure virtual machine cmdlets:  Stop-AzureVM -Name <TAB>'
+    )]
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+    #Write-Verbose -Message ('Called Azure Virtual Machine Name completer at {0}' -f (Get-Date));
+
+    ### Attempt to read Azure virtual machine details from the cache
+    $CacheKey = 'AzureVirtualMachine_NameCache';
+    $VirtualMachineNameCache = Get-CompletionPrivateData -Key $CacheKey;
+
+    ### If there is a valid cache for the Azure virtual machine names, then go ahead and return them immediately
+    if ($VirtualMachineNameCache -and (Get-Date) -gt $VirtualMachineNameCache.ExpirationTime) {
+        return $VirtualMachineNameCache;
+    }
+
+    ### Create fresh completion results for Azure virtual machines
+    $ItemList = Get-AzureVM | Where-Object { $PSItem.Name -match ${wordToComplete}; } | ForEach-Object {
+        $CompletionResult = @{
+            CompletionText = '{0} -ServiceName {1}' -f $PSItem.Name, $PSItem.ServiceName;
+            ToolTip = 'Azure VM {0}/{1} in state {2}.' -f $PSItem.ServiceName, $PSItem.Name, $PSItem.Status;
+            ListItemText = '{0}/{1}' -f $PSItem.ServiceName, $PSItem.Name;
+            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue;
+            };
+        New-CompletionResult @CompletionResult;
+    }
+    
+    ### Update the cache for Azure virtual machines
+    Set-CompletionPrivateData -Key $CacheKey -Value $ItemList;
+
+    ### Return the fresh completion results
+    return $ItemList;
+}

--- a/Microsoft.Azure.ArgumentCompleters.ps1
+++ b/Microsoft.Azure.ArgumentCompleters.ps1
@@ -21,6 +21,8 @@ function StorageAccount_StorageAccountNameCompleter
 
     $CacheKey = 'StorageAccount_StorageAccountNameCache';
     $StorageAccountNameCache = Get-CompletionPrivateData -Key $CacheKey;
+
+    ### Return the cached value if it has not expired
     if ($StorageAccountNameCache) {
         return $StorageAccountNameCache;
     }

--- a/Microsoft.Azure.ArgumentCompleters.ps1
+++ b/Microsoft.Azure.ArgumentCompleters.ps1
@@ -44,6 +44,47 @@ function StorageAccount_StorageAccountNameCompleter
 #
 # .SYNOPSIS
 #
+#    Auto-complete the -Name parameter value for Azure PowerShell storage container cmdlets.
+#
+# .NOTES
+#    
+#    Created by Trevor Sullivan <pcgeek86@gmail.com>
+#    http://trevorsullivan.net
+#
+function AzureStorage_StorageContainerNameCompleter
+{
+    [ArgumentCompleter(
+        Parameter = 'Name',
+        Command = { Get-CommandWithParameter -Module Azure -ParameterName Name -Name *container*; },
+        Description = 'Complete the -Name parameter value for Azure cmdlets:  Get-AzureStorageContainer -Context $Context -Name <TAB>'
+    )]
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+    $CacheKey = 'AzureStorage_ContainerNameCache';
+    $ContainerNameCache = Get-CompletionPrivateData -Key $CacheKey;
+
+    ### Return the cached value if it has not expired
+    if ($ContainerNameCache) {
+        return $ContainerNameCache;
+    }
+
+    $ContainerList = Get-AzureStorageContainer -Context $fakeBoundParameter['Context'] | Where-Object -FilterScript { $PSItem.Name -match ${wordToComplete}; } | ForEach-Object {
+        $CompletionResult = @{
+            CompletionText = $PSItem.Name;
+            ToolTip = 'Storage Container "{0}" in "{1}" Storage Account.' -f $PSItem.Name, $fakeBoundParameter['Context'].StorageAccountName;
+            ListItemText = '{0} ({1})' -f $PSItem.Name, $fakeBoundParameter['Context'].StorageAccountName;
+            CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue;
+            };
+        New-CompletionResult @CompletionResult;
+    }
+
+    Set-CompletionPrivateData -Key $CacheKey -Value $ContainerList;
+    return $ContainerList;
+}
+
+#
+# .SYNOPSIS
+#
 #    Auto-complete the -ServiceName parameter value for Azure PowerShell cmdlets.
 #
 # .NOTES

--- a/TabExpansion++.psm1
+++ b/TabExpansion++.psm1
@@ -44,14 +44,22 @@ function New-CompletionResult
           $ListItemText,
 
           [System.Management.Automation.CompletionResultType]
-          $CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue)
+          $CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue,
+ 
+          [Parameter(Mandatory = $false)]
+          [switch] $NoQuotes = $false
+          )
 
     process
     {
         $toolTipToUse = if ($ToolTip -eq '') { $CompletionText } else { $ToolTip }
         $listItemToUse = if ($ListItemText -eq '') { $CompletionText } else { $ListItemText }
 
-        if ($CompletionResultType -eq [System.Management.Automation.CompletionResultType]::ParameterValue)
+        # If the caller explicitly requests that quotes
+        # not be included, via the -NoQuotes parameter,
+        # then skip adding quotes.
+
+        if ($CompletionResultType -eq [System.Management.Automation.CompletionResultType]::ParameterValue -and -not $NoQuotes)
         {
             # Add single quotes for the caller in case they are needed.
             # We use the parser to robustly determine how it will treat
@@ -138,14 +146,14 @@ function Set-CompletionPrivateData
 
         [ValidateNotNullOrEmpty()]
         [int]
-        $ExpirationSeconds = 20
+        $ExpirationSeconds = 604800
         )
 
     $Cache = [PSCustomObject]@{
-        Value = $Value;
-        ExpirationTime = (Get-Date).AddSeconds($ExpirationSeconds);
-        };
-    $completionPrivateData[$key] = $Cache;
+        Value = $Value
+        ExpirationTime = (Get-Date).AddSeconds($ExpirationSeconds)
+        }
+    $completionPrivateData[$key] = $Cache
 }
 
 #############################################################################
@@ -159,9 +167,9 @@ function Get-CompletionPrivateData
 
     Flush-BackgroundResultsQueue;
 
-    $cacheValue = $completionPrivateData[$key];
+    $cacheValue = $completionPrivateData[$key]
     if ((Get-Date) -lt $cacheValue.ExpirationTime) {
-        return $cacheValue.Value;
+        return $cacheValue.Value
     }
 }
 
@@ -583,7 +591,7 @@ function Update-ArgumentCompleter
 # wildcards (asterisk).
 #
 # .EXAMPLE
-# Get-ArgumentComplete
+# Get-ArgumentCompleter -Name *Azure*;
 function Get-ArgumentCompleter
 {
     [CmdletBinding()]

--- a/TabExpansion++.psm1
+++ b/TabExpansion++.psm1
@@ -145,7 +145,6 @@ function Set-CompletionPrivateData
         Value = $Value;
         ExpirationTime = (Get-Date).AddSeconds($ExpirationSeconds);
         };
-    Add-Content -Path TabExpansion.log -Value ('Setting cache expiration time to: {0}. Key is: {1}' -f $Cache.ExpirationTime, $Key);
     $completionPrivateData[$key] = $Cache;
 }
 


### PR DESCRIPTION
Jason,

I've made two major changes in this Pull Request:

* Added a caching mechanism for completion results. Calls to `Set-CompletionPrivateData` can optionally include the `-ExpirationSeconds` parameter to specify the cache duration. Default value is currently `20`.
* Added three examples of auto-completer functions for the Microsoft Azure PowerShell module (Storage Account Names, Blob Container Names, Virtual Machine Names, and Subscription Names)

Cheers,
**Trevor Sullivan**
Microsoft MVP: PowerShell
http://trevorsullivan.net
http://twitter.com/pcgeek86