### PR TITLE
Fix native completion for words starting with '-'

### DIFF
--- a/TabExpansion++.psm1
+++ b/TabExpansion++.psm1
@@ -930,7 +930,7 @@ function TryNativeCommandOptionCompletion
             param($ast)
             return $offset -gt $ast.Extent.StartOffset -and
                    $offset -le $ast.Extent.EndOffset -and
-                   $ast.Extent.Text -in '-','--'
+                   $ast.Extent.Text.StartsWith('-')
         }
         $option = $ast.Find($offsetInOptionExtentPredicate, $true)
         if ($option -ne $null)

--- a/WindowsExe.ArgumentCompleters.ps1
+++ b/WindowsExe.ArgumentCompleters.ps1
@@ -30,7 +30,7 @@ function PowerShellExeCompletion
         {
             $completions = "Text", "XML"
         }
-        elseif ("WindowsStyle".StartsWith($parameterAst.ParameterName, "OrdinalIgnoreCase"))
+        elseif ("WindowStyle".StartsWith($parameterAst.ParameterName, "OrdinalIgnoreCase"))
         {
             $completions = "Normal", "Minimized", "Maximized", "Hidden"
         }
@@ -39,11 +39,9 @@ function PowerShellExeCompletion
             $completions = ([Microsoft.PowerShell.ExecutionPolicy] | Get-Member -Static -MemberType Property).Name
         }
 
-        foreach ($completion in $completions)
-        {
-            $tryParameters = $false
-            New-CompletionResult $completion
-        }
+        $tryParameters = ($completions.Length -eq 0)
+
+        $completions | Where-Object { $_ -match "^$wordToComplete" } | ForEach-Object { New-CompletionResult $_ }
     }
 
     if ($tryParameters -and ($wordToComplete.StartsWith("-") -or "" -eq $wordToComplete))


### PR DESCRIPTION
An apparent bug in PowerShell's default completion causes custom native completers to not be invoked for words starting with '-'.  A workaround exists to fix this, but only works for the words "-" and "--".

This minor change to the workaround makes it work for any word starting with '-', not just "-" and "--".

Also make some small fixes/enhancements to the powershell.exe argument completer.