### PR TITLE
Update TabExpansion++.psm1

### DIFF
--- a/TabExpansion++.psm1
+++ b/TabExpansion++.psm1
@@ -411,7 +411,7 @@ function Register-ArgumentCompleter
         # We can skip this step if we created the script block (Register-ArgumentCompleter was
         # called internally).
         if ($fnDefn -ne $null){
-            $ScriptBlock = $ScriptBlock.Ast.Body.GetScriptBlock()  # Don't reparse, just get a new ScriptBlock.
+            $ScriptBlock = (Get-PSCallStack)[0].InvocationInfo.MyCommand.Module.NewBoundScriptBlock($ScriptBlock);
         }
         else {
             $ScriptBlock = $ScriptBlock.Ast.GetScriptBlock()  # Don't reparse, just get a new ScriptBlock.


### PR DESCRIPTION
Adding proposed fix for GetScriptBlock(). If we use NewBoundScriptBlock() instead, we avoid the "Variable is not assigned in the method" exception.

Cheers,
Trevor Sullivan
Microsoft MVP: PowerShell