### PR TITLE
Support to display existing completionPrivateData

### DIFF
--- a/TabExpansionPlusPlus.psm1
+++ b/TabExpansionPlusPlus.psm1
@@ -167,6 +167,8 @@ function Get-CompletionPrivateData
         [string]
         $Key)
 
+    if(!$Key) 
+    { return $completionPrivateData }
 
     $cacheValue = $completionPrivateData[$key]
     if ((Get-Date) -lt $cacheValue.ExpirationTime) {


### PR DESCRIPTION
When not specifying the param -Key, show content of the CompletionPrivateData hashtable.
Allows for simple troubleshooting using Get-CompletionPrivateData from CLI.